### PR TITLE
Minor update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Reference [License](LICENSE) and [NOTICE](NOTICE) for details.
 
 ## Acknowledgements
 
-Some codes and design ideas were from other open source projects, such as PG-XC/XL(pgxc_ctl), TBase (timestamp based vacuum and MVCC), and CitusDB (pg_cron). Thanks for their contributions.
+Some codes and design ideas were from other open source projects, such as PG-XC/XL(pgxc_ctl), TBase (timestamp based vacuum and MVCC), and Citus (pg_cron). Thanks for their contributions.
 ___
 
 Copyright © Alibaba Group, Inc.


### PR DESCRIPTION
Minor correction to product name for Citus.

We changed the product name from CitusDB to Citus with the 5.0 release: https://www.citusdata.com/blog/2016/03/24/citus-unforks-goes-open-source/