### PR TITLE
to configure polardb on hunghu os

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,9 +32,22 @@ CMD=()
 
 CFLAGS="-fno-omit-frame-pointer -Wno-declaration-after-statement"
 LDFLAGS="-L/usr/local/lib"
+
+if [[ "$(uname -v)" =~ "hunghu-" ]]; then
+        PATH="/opt/local/gcc8/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin"
+	CFLAGS="${CFLAGS} -I/opt/local/include -I/usr/include"
+	CPPFLAGS="${CFLAGS} -I/opt/local/include -I/usr/include"
+	LDFLAGS="${LDFLAGS} -L/opt/local/lib -L/usr/lib"
+        LIBS="${LIBS} -l/usr/lib -l/opt/local/lib"
+        LD_LIBRARY_PATH="/usr/lib:/opt/local/lib"
+        export PATH LD_LIBRARY_PATH
+fi
+
 if [[ "$BLD_OPT" == "deploy" ]]; then
     CFLAGS="${CFLAGS} -g -O2"
     CMD+=(--with-python)
+    CMD+=(--with-openssl)
+    CMD+=(--enable-dtrace)
 elif [[ "$BLD_OPT" == "verify" ]]; then
     CFLAGS="${CFLAGS} -g -O2"
     CMD+=(--enable-cassert)
@@ -59,12 +72,24 @@ if [[ "$BLD_OPT" != "repeat" ]]; then
     ./configure --prefix=$PG_INSTALL ${CMD[@]}
 fi
 
+
+if [[ "$(uname -v)" =~ "hunghu-" ]]; then
+    echo ""
+    echo ">>>> CONFIGURE SUCCESS <<<<"
+    echo "configuration is done and success"
+    echo "since it is in the progress to porting libeasy to Hunghu OS"
+    echo "so just do configure right now, then it will exit"
+    echo ">>>> CONFIGURE SUCCESS <<<<"
+    echo ""
+    exit 0
+fi
+
 # build polardb consensus dynamic library
 cd $CODEHOME/src/backend/polar_dma/libconsensus/polar_wrapper
 if [[ "$BLD_OPT" == "debug" ]]; then
-bash ./build.sh -r -t debug
+    bash ./build.sh -r -t debug
 else
-bash ./build.sh -r -t release
+    bash ./build.sh -r -t release
 fi
 cd $CODEHOME
 

--- a/src/backend/polar_dma/libconsensus/dependency/easy/src/io/ev.c
+++ b/src/backend/polar_dma/libconsensus/dependency/easy/src/io/ev.c
@@ -183,7 +183,11 @@
 #include <sys/types.h>
 #include <time.h>
 #include <limits.h>
+#ifdef __linux__
 #include <syscall.h>
+#elif __solaris__
+#include <sys/syscall.h>
+#endif
 #include <signal.h>
 
 #ifdef EV_H

--- a/src/backend/polar_dma/libconsensus/dependency/easy/src/util/easy_inet.c
+++ b/src/backend/polar_dma/libconsensus/dependency/easy/src/util/easy_inet.c
@@ -21,7 +21,11 @@
 #include <netdb.h>
 #include <arpa/inet.h>      // inet_addr
 #include <sys/ioctl.h>
+#ifdef __linux__
 #include <linux/if.h>
+#elif __solaris__
+#include <net/if.h>
+#endif
 
 /**
  * 把sockaddr_in转成string


### PR DESCRIPTION
make polardb to support hunghu os, just complete the configure,

due to libeasy is in the porting progress , so don't compile the db, just don't complete configure, it is the first steps.

following is the testing screen dump, it successed
===========================
[tony@hosdev ~/PolarDB-for-PostgreSQL]$ ./build.sh
This script configure and build the code, It takes an optional
parameter that must be one of the following:
   deploy:   (default) configure the build with performance
             optimization options and build.
   verify:   configure the build with performance optimization
             with assertion enabled, and then build
   debug:    configure the build with debug options and then
             build.
   repeat:   skip configure, just build and install

~/PolarDB-for-PostgreSQL ~/PolarDB-for-PostgreSQL
PG installation dir: /home/tony/polardb/polardbhome
checking build system type... x86_64-pc-solaris2.11
checking host system type... x86_64-pc-solaris2.11
checking which template to use... solaris
checking whether NLS is wanted... no
checking for default port number... 5432
checking for dtrace... /usr/sbin/dtrace
checking for block size... 8kB
checking for segment size... 1GB
checking for WAL block size... 8kB
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking for gawk... gawk
checking whether gcc supports -Wdeclaration-after-statement, for CFLAGS... yes
checking whether gcc supports -Wendif-labels, for CFLAGS... yes
checking whether g++ supports -Wendif-labels, for CXXFLAGS... yes
checking whether gcc supports -Wmissing-format-attribute, for CFLAGS... yes
checking whether g++ supports -Wmissing-format-attribute, for CXXFLAGS... yes
checking whether gcc supports -Wformat-security, for CFLAGS... yes
checking whether g++ supports -Wformat-security, for CXXFLAGS... yes
checking whether gcc supports -fno-strict-aliasing, for CFLAGS... yes
checking whether g++ supports -fno-strict-aliasing, for CXXFLAGS... yes
checking whether gcc supports -fwrapv, for CFLAGS... yes
checking whether g++ supports -fwrapv, for CXXFLAGS... yes
checking whether gcc supports -fexcess-precision=standard, for CFLAGS... yes
checking whether g++ supports -fexcess-precision=standard, for CXXFLAGS... no
checking whether gcc supports -funroll-loops, for CFLAGS_VECTOR... yes
checking whether gcc supports -ftree-vectorize, for CFLAGS_VECTOR... yes
checking whether gcc supports -Wunused-command-line-argument, for NOT_THE_CFLAGS... no
checking whether gcc supports -Wformat-truncation, for NOT_THE_CFLAGS... yes
checking whether gcc supports -Wstringop-truncation, for NOT_THE_CFLAGS... yes
checking whether the C compiler still works... yes
checking how to run the C preprocessor... gcc -E
checking allow thread-safe client libraries... yes
checking whether to build with ICU support... no
checking whether to build with Tcl... no
checking whether to build Perl modules... no
checking whether to build Python modules... yes
checking whether to build with GSSAPI support... no
checking whether to build with PAM support... no
checking whether to build with BSD Authentication support... no
checking whether to build with LDAP support... no
checking whether to build with Bonjour support... no
checking whether to build with OpenSSL support... yes
checking whether to build with SELinux support... no
checking whether to build with systemd support... no
checking for grep that handles long lines and -e... /opt/local/bin/grep
checking for egrep... /opt/local/bin/grep -E
checking for ld used by GCC... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... no
checking for ranlib... ranlib
checking for strip... strip
checking whether it is possible to strip libraries... yes
checking for ar... ar
checking for a BSD-compatible install... /opt/local/bin/ginstall -c
checking for tar... /opt/local/bin/tar
checking whether ln -s works... yes
checking for a thread-safe mkdir -p... /opt/local/bin/mkdir -p
checking for bison... /opt/local/bin/bison
configure: using bison (GNU Bison) 3.0.4
checking for flex... /opt/local/bin/flex
configure: using flex 2.6.4
checking for perl... /opt/local/bin/perl
configure: using perl 5.28.1
checking for python... /opt/local/bin/python
configure: using python 2.7.15 (default, Sep 10 2019, 16:35:50)
checking for Python distutils module... yes
checking Python configuration directory... /opt/local/lib/python2.7/config
checking Python include directories... -I/opt/local/include/python2.7
checking how to link an embedded Python application... -L/opt/local/lib -lpython2.7 -lsocket -lnsl -ldl -lrt -lpthread -lm
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking if compiler needs certain flags to reject unknown flags... no
checking whether pthreads work with -mt -lpthread... no
checking whether pthreads work with -pthreads... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... -D_REENTRANT
checking for PTHREAD_PRIO_INHERIT... yes
checking pthread.h usability... yes
checking pthread.h presence... yes
checking for pthread.h... yes
checking for strerror_r... yes
checking for getpwuid_r... yes
checking for gethostbyname_r... no
checking whether strerror_r returns int... yes
checking for main in -lm... yes
checking for library containing setproctitle... no
checking for library containing dlopen... none required
checking for library containing socket... -lsocket
checking for library containing shl_load... no
checking for library containing getopt_long... none required
checking for library containing crypt... none required
checking for library containing shm_open... none required
checking for library containing shm_unlink... none required
checking for library containing clock_gettime... none required
checking for library containing fdatasync... none required
checking for library containing sched_yield... none required
checking for library containing gethostbyname_r... -lnsl
checking for library containing shmget... none required
checking for library containing readline... -lreadline
checking for inflate in -lz... yes
checking for CRYPTO_new_ex_data in -lcrypto... yes
checking for SSL_new in -lssl... yes
checking for SSL_clear_options... no
checking for SSL_get_current_compression... yes
checking for X509_get_signature_nid... yes
checking for OPENSSL_init_ssl... no
checking for BIO_get_data... no
checking for BIO_meth_new... no
checking for ASN1_STRING_get0_data... no
checking for RAND_OpenSSL... no
checking for CRYPTO_lock... yes
checking for stdbool.h that conforms to C99... yes
checking for _Bool... yes
checking atomic.h usability... yes
checking atomic.h presence... yes
checking for atomic.h... yes
checking crypt.h usability... yes
checking crypt.h presence... yes
checking for crypt.h... yes
checking dld.h usability... no
checking dld.h presence... no
checking for dld.h... no
checking fp_class.h usability... no
checking fp_class.h presence... no
checking for fp_class.h... no
checking getopt.h usability... yes
checking getopt.h presence... yes
checking for getopt.h... yes
checking ieeefp.h usability... yes
checking ieeefp.h presence... yes
checking for ieeefp.h... yes
checking ifaddrs.h usability... yes
checking ifaddrs.h presence... yes
checking for ifaddrs.h... yes
checking langinfo.h usability... yes
checking langinfo.h presence... yes
checking for langinfo.h... yes
checking mbarrier.h usability... no
checking mbarrier.h presence... no
checking for mbarrier.h... no
checking poll.h usability... yes
checking poll.h presence... yes
checking for poll.h... yes
checking sys/epoll.h usability... yes
checking sys/epoll.h presence... yes
checking for sys/epoll.h... yes
checking sys/ipc.h usability... yes
checking sys/ipc.h presence... yes
checking for sys/ipc.h... yes
checking sys/pstat.h usability... no
checking sys/pstat.h presence... no
checking for sys/pstat.h... no
checking sys/resource.h usability... yes
checking sys/resource.h presence... yes
checking for sys/resource.h... yes
checking sys/select.h usability... yes
checking sys/select.h presence... yes
checking for sys/select.h... yes
checking sys/sem.h usability... yes
checking sys/sem.h presence... yes
checking for sys/sem.h... yes
checking sys/shm.h usability... yes
checking sys/shm.h presence... yes
checking for sys/shm.h... yes
checking sys/sockio.h usability... yes
checking sys/sockio.h presence... yes
checking for sys/sockio.h... yes
checking sys/tas.h usability... no
checking sys/tas.h presence... no
checking for sys/tas.h... no
checking sys/un.h usability... yes
checking sys/un.h presence... yes
checking for sys/un.h... yes
checking termios.h usability... yes
checking termios.h presence... yes
checking for termios.h... yes
checking ucred.h usability... yes
checking ucred.h presence... yes
checking for ucred.h... yes
checking utime.h usability... yes
checking utime.h presence... yes
checking for utime.h... yes
checking wchar.h usability... yes
checking wchar.h presence... yes
checking for wchar.h... yes
checking wctype.h usability... yes
checking wctype.h presence... yes
checking for wctype.h... yes
checking for net/if.h... yes
checking for sys/ucred.h... yes
checking for netinet/tcp.h... yes
checking readline/readline.h usability... yes
checking readline/readline.h presence... no
configure: WARNING: readline/readline.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: readline/readline.h: proceeding with the compiler's result
checking for readline/readline.h... yes
checking readline/history.h usability... yes
checking readline/history.h presence... no
configure: WARNING: readline/history.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: readline/history.h: proceeding with the compiler's result
checking for readline/history.h... yes
checking zlib.h usability... yes
checking zlib.h presence... no
configure: WARNING: zlib.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: zlib.h: proceeding with the compiler's result
checking for zlib.h... yes
checking openssl/ssl.h usability... yes
checking openssl/ssl.h presence... no
configure: WARNING: openssl/ssl.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/ssl.h: proceeding with the compiler's result
checking for openssl/ssl.h... yes
checking openssl/err.h usability... yes
checking openssl/err.h presence... no
configure: WARNING: openssl/err.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/err.h: proceeding with the compiler's result
checking for openssl/err.h... yes
checking whether byte ordering is bigendian... no
checking for inline... inline
checking for printf format archetype... gnu_printf
checking for flexible array members... yes
checking for signed types... yes
checking for __func__... yes
checking for _Static_assert... yes
checking for typeof... typeof
checking for __builtin_types_compatible_p... yes
checking for __builtin_bswap16... yes
checking for __builtin_bswap32... yes
checking for __builtin_bswap64... yes
checking for __builtin_constant_p... yes
checking for __builtin_unreachable... yes
checking for computed goto support... yes
checking for __VA_ARGS__... yes
checking whether struct tm is in sys/time.h or time.h... time.h
checking for struct tm.tm_zone... no
checking for tzname... yes
checking for union semun... no
checking for struct sockaddr_un... yes
checking for struct sockaddr_storage... yes
checking for struct sockaddr_storage.ss_family... yes
checking for struct sockaddr_storage.__ss_family... no
checking for struct sockaddr_storage.ss_len... no
checking for struct sockaddr_storage.__ss_len... no
checking for struct sockaddr.sa_len... no
checking for struct addrinfo... yes
checking for intptr_t... yes
checking for uintptr_t... yes
checking for unsigned long long int... yes
checking for long long int... yes
checking for locale_t... yes
checking for C/C++ restrict keyword... __restrict
checking for struct cmsgcred... no
checking for struct option... yes
checking for z_streamp... yes
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking size of off_t... 8
checking size of bool... 1
checking for int timezone... yes
checking types of arguments for accept()... int, int, struct sockaddr *, int *
checking whether gettimeofday takes only one argument... no
checking for wcstombs_l declaration... yes (in xlocale.h)
checking for cbrt... yes
checking for clock_gettime... yes
checking for dlopen... yes
checking for fdatasync... yes
checking for getifaddrs... yes
checking for getpeerucred... yes
checking for getrlimit... yes
checking for mbstowcs_l... yes
checking for memmove... yes
checking for poll... yes
checking for posix_fallocate... yes
checking for pstat... no
checking for pthread_is_threaded_np... no
checking for readlink... yes
checking for setproctitle... no
checking for setsid... yes
checking for shm_open... yes
checking for symlink... yes
checking for sync_file_range... no
checking for uselocale... yes
checking for utime... yes
checking for utimes... yes
checking for wcstombs_l... yes
checking for fseeko... yes
checking for _LARGEFILE_SOURCE value needed for large files... no
checking how gcc reports undeclared, standard C functions... error
checking whether fdatasync is declared... yes
checking whether strlcat is declared... yes
checking whether strlcpy is declared... yes
checking whether strnlen is declared... yes
checking whether F_FULLFSYNC is declared... no
checking for struct sockaddr_in6... yes
checking for PS_STRINGS... no
checking for snprintf... yes
checking for vsnprintf... yes
checking whether snprintf is declared... yes
checking whether vsnprintf is declared... yes
checking for isinf... yes
checking for crypt... yes
checking for fls... yes
checking for getopt... yes
checking for getrusage... yes
checking for inet_aton... yes
checking for mkdtemp... yes
checking for random... yes
checking for rint... yes
checking for srandom... yes
checking for strerror... yes
checking for strlcat... yes
checking for strlcpy... yes
checking for strnlen... yes
checking for unsetenv... yes
checking for getpeereid... no
checking for getaddrinfo... yes
checking for getopt_long... yes
checking whether sys_siglist is declared... no
checking for syslog... yes
checking syslog.h usability... yes
checking syslog.h presence... yes
checking for syslog.h... yes
checking for opterr... yes
checking for optreset... no
checking for strtoll... yes
checking for strtoull... yes
checking whether strtoll is declared... yes
checking whether strtoull is declared... yes
checking for rl_completion_append_character... yes
checking for rl_completion_matches... yes
checking for rl_filename_completion_function... yes
checking for rl_reset_screen_size... yes
checking for append_history... yes
checking for history_truncate_file... yes
checking test program... ok
checking whether long int is 64 bits... yes
checking whether snprintf supports the %z modifier... yes
checking for __builtin_mul_overflow... yes
checking size of void *... 8
checking size of size_t... 8
checking size of long... 8
checking whether to build with float4 passed by value... yes
checking whether to build with float8 passed by value... yes
checking alignment of short... 2
checking alignment of int... 4
checking alignment of long... 8
checking alignment of double... 8
checking for int8... no
checking for uint8... no
checking for int64... no
checking for uint64... no
checking for __int128... yes
checking for __int128 alignment bug... ok
checking alignment of PG_INT128_TYPE... 16
checking for builtin __sync char locking functions... yes
checking for builtin __sync int32 locking functions... yes
checking for builtin __sync int32 atomic operations... yes
checking for builtin __sync int64 atomic operations... yes
checking for builtin __atomic int32 atomic operations... yes
checking for builtin __atomic int64 atomic operations... yes
checking for __get_cpuid... yes
checking for __cpuid... no
checking for _mm_crc32_u8 and _mm_crc32_u32 with CFLAGS=... no
checking for _mm_crc32_u8 and _mm_crc32_u32 with CFLAGS=-msse4.2... yes
checking for __crc32cb, __crc32ch, __crc32cw, and __crc32cd with CFLAGS=... no
checking for __crc32cb, __crc32ch, __crc32cw, and __crc32cd with CFLAGS=-march=armv8-a+crc... no
checking which CRC-32C implementation to use... SSE 4.2 with runtime check
checking which semaphore API to use... System V
checking which random number source to use... OpenSSL
checking Python.h usability... yes
checking Python.h presence... yes
checking for Python.h... yes
checking for xmllint... /opt/local/bin/xmllint
checking for DocBook XML V4.2... yes
checking for dbtoepub... no
checking for xsltproc... /opt/local/bin/xsltproc
checking for fop... no
checking thread safety of required library functions... yes
checking whether gcc supports -Wl,--as-needed... no
configure: using compiler=gcc (GCC) 8.2.0
configure: using CFLAGS=-Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -fno-omit-frame-pointer -Wno-declaration-after-statement -I/opt/local/include -I/usr/include -g -O2
configure: using CPPFLAGS=
configure: using LDFLAGS=-L/usr/local/lib -L/opt/local/lib -L/usr/lib
configure: creating ./config.status
config.status: creating GNUmakefile
config.status: creating src/Makefile.global
config.status: creating src/include/pg_config.h
config.status: src/include/pg_config.h is unchanged
config.status: creating src/include/pg_config_ext.h
config.status: src/include/pg_config_ext.h is unchanged
config.status: creating src/interfaces/ecpg/include/ecpg_config.h
config.status: src/interfaces/ecpg/include/ecpg_config.h is unchanged
config.status: linking src/backend/port/tas/dummy.s to src/backend/port/tas.s
config.status: linking src/backend/port/dynloader/solaris.c to src/backend/port/dynloader.c
config.status: linking src/backend/port/sysv_sema.c to src/backend/port/pg_sema.c
config.status: linking src/backend/port/sysv_shmem.c to src/backend/port/pg_shmem.c
config.status: linking src/backend/port/dynloader/solaris.h to src/include/dynloader.h
config.status: linking src/include/port/solaris.h to src/include/pg_config_os.h
config.status: linking src/makefiles/Makefile.solaris to src/Makefile.port

>>>> CONFIGURE SUCCESS <<<<
configuration is done and success
since it is in the progress to porting libeasy to Hunghu OS
so just do configure right now, then it will exit
>>>> CONFIGURE SUCCESS <<<<

[tony@hosdev ~/PolarDB-for-PostgreSQL]$