### PR TITLE
默认把tcp keepalives打开防止某些时候hang

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1245,6 +1245,19 @@ setup_config(void)
 								  "log_file_mode = 0640");
 	}
 
+	/*
+	 *   set tcp keepalive to on, prevent some problems caused by network instability.
+	 */
+	snprintf(repltok, sizeof(repltok), "tcp_keepalives_idle = 5");
+	conflines = replace_token(conflines, "#tcp_keepalives_idle = 0", repltok);
+
+	snprintf(repltok, sizeof(repltok), "tcp_keepalives_interval = 5");
+	conflines = replace_token(conflines, "#tcp_keepalives_interval = 0", repltok);
+
+	snprintf(repltok, sizeof(repltok), "tcp_keepalives_count = 3");
+	conflines = replace_token(conflines, "#tcp_keepalives_count = 0", repltok);
+
+
 	snprintf(path, sizeof(path), "%s/postgresql.conf", pg_data);
 
 	writefile(path, conflines);


### PR DESCRIPTION
从最佳实践看，把tcp_keepalive打开会防止因网络不稳定导致的hang的问题，这几个参数在默认生成的postgresql.conf设置为：
tcp_keepalives_idle = 5
tcp_keepalives_interval = 5
tcp_keepalive_count =3 
