### PR TITLE
[Bug] Fix polardb_build.sh

### DIFF
--- a/polardb_build.sh
+++ b/polardb_build.sh
@@ -14,6 +14,7 @@
 
 set -x
 set -e
+set -o pipefail
 
 ##################### Function Defination Start #####################
 function usage() {
@@ -110,6 +111,7 @@ function check_core() {
 }
 
 function check_failed_case() {
+  set +e
   failcases=$(grep "\.\. FAILED" testlog | head -n 1)
   failcases=$(grep "\.\. Failed" testlog | head -n 1)$failcases
   failcases=$(grep "CMake Error at" testlog | head -n 1)$failcases
@@ -145,6 +147,7 @@ function check_failed_case() {
     echo "==========================="
     echo ""
   fi
+  set -e
 }
 
 function polar_stop_database() {
@@ -248,12 +251,12 @@ function polar_test_non_polar() {
   if [[ $make_check_world == "on" ]]; then
     unset COPT
     su_eval "make check-world PG_TEST_EXTRA='kerberos ldap ssl' 2>&1" | tee -a testlog
-    su_eval "make polar-check 2>&1" | tee -a testlog
+    su_eval "make -C src/test/regress polar-check 2>&1" | tee -a testlog
     check_failed_case "check-world"
   fi
 
   if [[ $regress_test == "on" ]]; then
-    su_eval "make polar-check 2>&1" | tee -a testlog
+    su_eval "make -C src/test/regress polar-check 2>&1" | tee -a testlog
     if [ -e ./src/test/regress/regression.diffs ]; then
       cat ./src/test/regress/regression.diffs
       exit 1
@@ -369,12 +372,6 @@ function polar_init_standby() {
 }
 
 function polar_init() {
-  if [[ "$EUID" == 0 ]]; then
-    chown -R $polar_user ../polardb_pg
-    chown -R $polar_user $polar_basedir
-    chown -R $polar_user $polar_primary_dir
-  fi
-
   polar_init_primary
 
   polar_init_replicas
@@ -403,9 +400,9 @@ function polar_start() {
 
   echo "Following command can be used to connect to PG:"
   echo ""
-  echo su $polar_user -c \"$polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_port postgres \"
-  echo su $polar_user -c \"$polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_rep_port postgres \"
-  echo su $polar_user -c \"$polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_standby_port postgres \"
+  echo $polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_port postgres
+  echo $polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_rep_port postgres
+  echo $polar_basedir/bin/psql -h 127.0.0.1 -d -p $polar_standby_port postgres
   echo ""
 }
 
@@ -418,7 +415,7 @@ function polar_test_regress() {
       cat ./src/test/regress/regression.diffs
     fi
 
-    su_eval "make polar-installcheck 2>&1" | tee -a testlog
+    su_eval "make -C src/test/regress polar-installcheck 2>&1" | tee -a testlog
 
     if [ -e ./src/test/regress/regression.diffs ]; then
       cat ./src/test/regress/regression.diffs
@@ -472,7 +469,7 @@ function polar_test_installcheck() {
   if [[ $make_installcheck_world == "on" ]] && [[ $regress_test_quick == "off" ]]; then
     export PGHOST=/tmp
     su_eval "make installcheck-world PG_TEST_EXTRA='kerberos ldap ssl' 2>&1" | tee -a testlog
-    su_eval "make polar-installcheck 2>&1" | tee -a testlog
+    su_eval "make -C src/test/regress polar-installcheck 2>&1" | tee -a testlog
     check_failed_case "installcheck-world"
     unset PGHOST
   fi
@@ -613,11 +610,6 @@ unset PGDATA
 unset PGHOST
 unset PGDATABASE
 unset PGUSER
-
-if [[ "$EUID" == 0 ]]; then
-  echo "Running with user $polar_user!"
-  su_str="su $polar_user -c "
-fi
 
 ####### PHASE 2: cleanup dir and env, and set new dir and env #######
 polar_reset_dir


### PR DESCRIPTION
1. Remove uncomplete support for running with root privileges;
2. Fix the execution path of `make polar-check` and `make polar-installcheck`.