### PR TITLE
[Porting] Add .editorconfig from PG community

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*.{c,h,l,y,pl,pm}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.{sgml,xml}]
+indent_style = space
+indent_size = 1
+
+[*.xsl]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Port `.editorconfig` from PG [community](https://github.com/postgres/postgres/blob/master/.editorconfig), so that the tab size of online code view will be 4 spaces. It will make code style of online review prettier.