### PR TITLE
[Doc] Add --with-pfsd to the command used for compiling the kernel.

### DIFF
--- a/docs/guide/deploy-on-nbd-shared-storage.md
+++ b/docs/guide/deploy-on-nbd-shared-storage.md
@@ -149,7 +149,7 @@ sudo /usr/local/polarstore/pfsd/bin/start_pfsd.sh -p nvme0n1
 #### 内核编译
 
 ```bash
-./polardb_build.sh
+./polardb_build.sh --with-pfsd
 ```
 
 #### 节点初始化
@@ -215,7 +215,7 @@ $HOME/tmp_basedir_polardb_pg_1100_bld/bin/psql -p 5432 -d postgres -c "select pg
 #### 内核编译
 
 ```bash
-./polardb_build.sh
+./polardb_build.sh --with-pfsd
 ```
 
 #### 节点初始化

--- a/docs/zh/guide/deploy-on-nbd-shared-storage.md
+++ b/docs/zh/guide/deploy-on-nbd-shared-storage.md
@@ -145,7 +145,7 @@ sudo /usr/local/polarstore/pfsd/bin/start_pfsd.sh -p nvme0n1
 #### 内核编译
 
 ```bash
-./polardb_build.sh
+./polardb_build.sh --with-pfsd
 ```
 
 #### 节点初始化
@@ -211,7 +211,7 @@ $HOME/tmp_basedir_polardb_pg_1100_bld/bin/psql -p 5432 -d postgres -c "select pg
 #### 内核编译
 
 ```bash
-./polardb_build.sh
+./polardb_build.sh --with-pfsd
 ```
 
 #### 节点初始化


### PR DESCRIPTION
For deploying an instance based on the NBD shared storage, add the parameter "--with-pfsd" to the command ./polardb_build.sh which is used to compile kernels on the primary node and read-only nodes. 
This suggestion is provided by @学弈. 
English documents have been updated on GitLab: http://gitlab.alibaba-inc.com/rds_pg/PolarDB-for-PostgreSQL/blob/POLARDB_11_STABLE_docs_lixia/docs/guide/deploy-on-nbd-shared-storage.md.