### PR TITLE
fix: PX remove notice message queue of QC

### DIFF
--- a/src/backend/px/dispatcher/px_disp_async.c
+++ b/src/backend/px/dispatcher/px_disp_async.c
@@ -589,8 +589,6 @@ dispatchCommand(PxDispatchResult *dispatchResult,
 						dispatchResult->pxWorkerDesc->whoami, msg ? msg : "unknown error")));
 	}
 
-	forwardPXNotices();
-
 	if (DEBUG1 >= log_min_messages)
 	{
 		TimestampDifference(beforeSend, GetCurrentTimestamp(), &secs, &usecs);
@@ -657,7 +655,6 @@ handlePollError(PxDispatchCmdAsync *pParms)
 			dispatchResult->stillRunning = false;
 		}
 	}
-	forwardPXNotices();
 
 	return;
 }
@@ -862,7 +859,6 @@ processResults(PxDispatchResult *dispatchResult)
 									   pxWorkerDesc->whoami, msg ? msg : "unknown error");
 		return true;
 	}
-	forwardPXNotices();
 
 	/*
 	 * If we have received one or more complete messages, process them.
@@ -873,8 +869,6 @@ processResults(PxDispatchResult *dispatchResult)
 		PGresult   *pRes;
 		ExecStatusType resultStatus;
 		int			resultIndex;
-
-		forwardPXNotices();
 
 		/*
 		 * PQisBusy() does some error handling, which can cause the connection
@@ -996,8 +990,6 @@ processResults(PxDispatchResult *dispatchResult)
 		}
 	}
 
-	forwardPXNotices();
-
 	/*
 	 * If there was nextval request then respond back on this libpq connection
 	 * with the next value. Check and process nextval message only if QC has
@@ -1048,8 +1040,6 @@ processResults(PxDispatchResult *dispatchResult)
 	if (nextval)
 		PQfreemem(nextval);
 
-	forwardPXNotices();
-
 	return false;				/* we must keep on monitoring this socket */
 }
 
@@ -1082,7 +1072,6 @@ checkDispatchResult_thread(PxDispatcherState *ds, bool wait)
 		}
 		if (!wait || is_all_finish)
 			break;
-		forwardPXNotices();
 		pg_usleep(1);
 	}
 	elog(DEBUG5, "pq_thread: finish check dispatch result from libpq thread.");

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -1673,27 +1673,37 @@ SendQuery(const char *query)
 
 				if (!enable_px)
 				{
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, "SET polar_enable_px=1;");
+					ResetCancelConn();
 					PQclear(tmp_results);
 				}
 
 				if (need_analyze && 
 					(pset.explain_query || pset.explain_analyze))
 				{
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, "SET client_min_messages='FATAL';");
+					ResetCancelConn();
 					PQclear(tmp_results);
 
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, "ANALYZE");
+					ResetCancelConn();
 					PQclear(tmp_results);
 					need_analyze = false;
 
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, "RESET client_min_messages;");
+					ResetCancelConn();
 					PQclear(tmp_results);
 				}
 
-				new_query = (char*)malloc(query_len);
+				new_query = (char*) malloc(query_len);
 				snprintf(new_query, query_len, "EXPLAIN (VERBOSE, COSTS OFF) %s", query);
+				SetCancelConn();
 				tmp_results = PQexec(pset.db, new_query);
+				ResetCancelConn();
 				free(new_query);
 
 				tmp_OK = ProcessResult(&tmp_results);
@@ -1712,9 +1722,11 @@ SendQuery(const char *query)
 
 				if (pset.explain_analyze)
 				{
-					new_query = (char*)malloc(query_len);
+					new_query = (char*) malloc(query_len);
 					snprintf(new_query, query_len, "EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) %s", query);
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, new_query);
+					ResetCancelConn();
 					free(new_query);
 
 					tmp_OK = ProcessResult(&tmp_results);
@@ -1734,7 +1746,9 @@ SendQuery(const char *query)
 
 				if (is_px_used)
 				{
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, query);
+					ResetCancelConn();
 					result_status_px = PQresultStatus(tmp_results);
 					result_hash_px = polar_calc_result_hash(tmp_results, &pset.popt);
 					tmp_OK = ProcessResult(&tmp_results);
@@ -1748,13 +1762,15 @@ SendQuery(const char *query)
 					{
 						pset.popt.sort_result = true;
 						PrintQueryResults(tmp_results);
-						PQclear(tmp_results);
 					}
+					PQclear(tmp_results);
 				}
 
 				if (!enable_px)
 				{
+					SetCancelConn();
 					tmp_results = PQexec(pset.db, "SET polar_enable_px=0;");
+					ResetCancelConn();
 					PQclear(tmp_results);
 				}
 			}

--- a/src/include/px/px_conn.h
+++ b/src/include/px/px_conn.h
@@ -98,6 +98,4 @@ void		pxconn_setPXIdentifier(PxWorkerDescriptor *pxWorkerDesc, int sliceIndex);
  */
 bool		pxconn_signalPX(PxWorkerDescriptor *pxWorkerDesc, char *errbuf, bool isCancel);
 
-extern void forwardPXNotices(void);
-
 #endif							/* PXCONN_H */


### PR DESCRIPTION
Currently, QC maintains a notice message queue which contains the
gathered notice message from PX node. It will make the display of notice
message on client unstable. This commit removes this queue, and will
forward a notice message from PX node to client right away.