### PR TITLE
fix: polar_px extension does not specify schema

### DIFF
--- a/external/polar_px/polar_px.control
+++ b/external/polar_px/polar_px.control
@@ -2,5 +2,4 @@
 comment = 'Parallel Execution extension'
 default_version = '1.0'
 module_pathname = '$libdir/polar_px'
-relocatable = true
-
+schema = 'public'

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -308,6 +308,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 */
 	/* POLAR px */
 	local_px_insert_dop_num = px_insert_dop_num;
+	px_workerid_funcid = InvalidOid;
 
 	if ((cursorOptions & CURSOR_OPT_PX_OK) && should_px_planner(parse))
 	{

--- a/src/backend/px/px_mutate.c
+++ b/src/backend/px/px_mutate.c
@@ -787,23 +787,19 @@ pxhash_const_list(List *plConsts, int iSegments, Oid *hashfuncs)
 }
 
 /*
- * Construct an expression that checks whether the current segment is
- * 'segid'.
+ * Construct an expression that checks whether the current worker is
+ * 'workerid'.
  */
 Node *
-makePXWorkerIndexFilterExpr(int segid)
+makePXWorkerIndexFilterExpr(int workerid)
 {
 	/* 
-	 * get px_workerid_funcid every time, 
-	 * for case user reinstall polar_px plugin many times,
-	 * and funcid changed.
+	 * get px_workerid_funcid if it is InvalidOid.
 	 */
-	update_px_workerid_funcid();
+	if (px_workerid_funcid == InvalidOid)
+		update_px_workerid_funcid();
 
-	Assert(px_workerid_funcid != InvalidOid);
-	elog(DEBUG5, "px_workerid_funcid: %d", px_workerid_funcid);
-
-	/* Build an expression: gp_execution_segment() = <segid> */
+	/* Build an expression: polar_px_workerid() = <workerid> */
 	return (Node *)
 		make_opclause(Int4EqualOperator,
 					  BOOLOID,
@@ -818,7 +814,7 @@ makePXWorkerIndexFilterExpr(int segid)
 										 -1,		/* consttypmod */
 										 InvalidOid, /* constcollid */
 										 sizeof(int32),
-										 Int32GetDatum(segid),
+										 Int32GetDatum(workerid),
 										 false,		/* constisnull */
 										 true),		/* constbyval */
 					  InvalidOid,	/* opcollid */

--- a/src/backend/px/px_vars.c
+++ b/src/backend/px/px_vars.c
@@ -198,6 +198,7 @@ get_px_workerid(void)
 uint32
 get_px_workerid_funcid(void)
 {
+	update_px_workerid_funcid();
 	return px_workerid_funcid;
 }
 
@@ -207,11 +208,11 @@ update_px_workerid_funcid(void)
 	List		*funcname = NIL;
 	Oid			fargtypes[1];	/* dummy */
 
-	funcname = list_make1(makeString(px_workerid_funcname));
-	px_workerid_funcid = LookupFuncName(funcname, 0, fargtypes, false);
+	funcname = list_make2(makeString("public"), makeString(px_workerid_funcname));
+	px_workerid_funcid = LookupFuncName(funcname, 0, fargtypes, true);
 
-	if(px_workerid_funcid == InvalidOid)
-			elog(ERROR, "load polar_px extension.");
+	if (px_workerid_funcid == InvalidOid)
+		elog(ERROR, "polar_px: load polar_px_workerid() failed, try \"CREATE EXTENSION polar_px;\"");
 }
 
 bool

--- a/src/test/regress/px_expected/polar-px-dev/tableless_scan.out
+++ b/src/test/regress/px_expected/polar-px-dev/tableless_scan.out
@@ -25,8 +25,6 @@ select * from ((select a as x from csq_r) union (select 1 as x )) as foo order b
  1
 (1 row)
 
-ERROR:  function polar_px_workerid() does not exist
-----COMPARE PX RESULT explain query failed
 explain (costs off, verbose)
 select (select generate_series(1,5));
                QUERY PLAN                
@@ -68,8 +66,6 @@ select * from ((select a as x from csq_r) union (select 1 as x )) as foo order b
  1
 (1 row)
 
-ERROR:  function polar_px_workerid() does not exist
-----COMPARE PX RESULT explain query failed
 explain (costs off, verbose)
 select (select generate_series(1,5));
                QUERY PLAN                


### PR DESCRIPTION
If we do not specify the SCHEMA of polar_px extension, PX may fail to create plan after SCHEMA change. That is because we can not get px_workerid_funcid after SCHEMA change.