### PR TITLE
increase insert xxx  select xxx speed

### DIFF
--- a/src/backend/storage/buffer/freelist.c
+++ b/src/backend/storage/buffer/freelist.c
@@ -581,7 +581,7 @@ GetAccessStrategy(BufferAccessStrategyType btype)
 			return NULL;
 
 		case BAS_BULKREAD:
-			ring_size = 256 * 1024 / BLCKSZ;
+			ring_size = 1024 * 1024 / BLCKSZ;
 			break;
 		case BAS_BULKWRITE:
 			ring_size = 16 * 1024 * 1024 / BLCKSZ;


### PR DESCRIPTION
when increase polar_bulk_read_size to 64, but "insert xxx select" not getting faster, because ring_size is low，so increase ring_size in function GetAccessStrategy.

test:

```
postgres=# reset polar_bulk_read_size;
RESET
Time: 0.200 ms
postgres=# show polar_bulk_read_size;
 polar_bulk_read_size
----------------------
 128kB
(1 row)

Time: 0.216 ms
postgres=# select count(*) from test2;
   count
-----------
 200000000
(1 row)

Time: 96621.768 ms (01:36.622)

postgres=# set polar_bulk_read_size to 64;
SET
postgres=# set max_parallel_workers_per_gather to 0;
SET
postgres=# \timing
Timing is on.
postgres=# select count(*) from test2;
   count
-----------
 200000000
(1 row)

Time: 73271.417 ms (01:13.271)

postgres=# set max_parallel_workers_per_gather to 8;
SET
Time: 0.173 ms
postgres=# explain select count(*) from test2;
                                         QUERY PLAN
---------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=9009314.43..9009314.44 rows=1 width=8)
   ->  Gather  (cost=9009313.60..9009314.41 rows=8 width=8)
         Workers Planned: 8
         ->  Partial Aggregate  (cost=9008313.60..9008313.61 rows=1 width=8)
               ->  Parallel Seq Scan on test2  (cost=0.00..8945812.48 rows=25000448 width=0)
(5 rows)

Time: 0.454 ms
postgres=# select count(*) from test2;
   count
-----------
 200000000
(1 row)

Time: 92410.190 ms (01:32.410)

postgres=# set polar_bulk_read_size to 64;
SET
Time: 0.168 ms
postgres=# show polar_bulk_read_size;
 polar_bulk_read_size
----------------------
 512kB
(1 row)

Time: 0.154 ms
postgres=# select count(*) from test2;
   count
-----------
 200000000
(1 row)

Time: 75722.028 ms (01:15.722)
```
