### PR TITLE
ci: disable rocky 8/9 RPM building

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base_image: [ centos7, anolis8, rocky8, rocky9 ]
+        # base_image: [ centos7, anolis8, rocky8, rocky9 ]
+        base_image: [ centos7, anolis8 ]
     steps:
       - name: Fetch source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Due to Rocky 8/9 starts to use LLVM 17, which cannot be adapted to PostgreSQL 11, temporarily disable the RPM packaging.