### PR TITLE
fix: clean up code to eliminate compilation warnings

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1844,7 +1844,7 @@ static int
 ServerLoop(void)
 {
 	fd_set		readmask, readmask_base;
-	int			nSockets, nSockets_base;
+	int			nSockets, nSockets_base = 0;
 	time_t		last_lockfile_recheck_time,
 				last_touch_time;
 

--- a/src/backend/storage/buffer/polar_bufmgr.c
+++ b/src/backend/storage/buffer/polar_bufmgr.c
@@ -1339,8 +1339,6 @@ repeat_read:
 	 */
 	for (index = actual_bulk_io_count - 1; index >= 0 ; index--)
 	{
-		BlockNumber blockNum = firstBlockNum + index;
-
 		bufHdr = polar_bulk_io_in_progress_buf[index];
 		bufBlock = isLocalBuf ? LocalBufHdrGetBlock(bufHdr) : BufHdrGetBlock(bufHdr);
 

--- a/src/backend/utils/misc/guc_px.c
+++ b/src/backend/utils/misc/guc_px.c
@@ -284,7 +284,6 @@ int			px_wait_lock_timeout = 0;
 /* POLAR */
 static bool px_check_dispatch_log_stats(bool *newval, void **extra, GucSource source);
 static bool px_check_scan_unit_size(int *newval, void **extra, GucSource source);
-static const char* px_show_scan_unit_size(void);
 static bool px_check_ignore_function(char **newval, void **extra, GucSource source);
 static void px_assign_ignore_function(const char *newval, void *extra);
 static int px_guc_array_compare(const void *a, const void *b);


### PR DESCRIPTION
1. Assign an initial value of 0 to the 'nSockets_base' variable to prevent the compilation warning 'may be used uninitialized in this function'.
2. Delete the 'blockNum' variable, which is defined but not used in the 'polar_bulk_read_buffer_common' function.
3. Delete the unused function definition 'px_show_scan_unit_size' from the 'guc_px.c' file. The implementation of this function has been removed in the d52e8258 commit.

![image](https://github.com/user-attachments/assets/c1e71c4e-4173-439f-ab2c-de9e663922ec)
