### PR TITLE
feat: RSC adapt to c99 standard

### DIFF
--- a/src/include/storage/polar_rsc.h
+++ b/src/include/storage/polar_rsc.h
@@ -34,7 +34,6 @@
 #include "port/atomics.h"
 #include "storage/block.h"
 #include "storage/relfilenode.h"
-#include "storage/smgr.h"
 #include "utils/relcache.h"
 
 /* GUCs */
@@ -121,13 +120,13 @@ typedef struct polar_rsc_stat_t
 
 extern polar_rsc_stat_t *polar_rsc_global_stat;
 
-typedef struct SMgrRelationData *SMgrRelation;
+struct SMgrRelationData;
 
-extern BlockNumber smgrnblocks_real(SMgrRelation reln, ForkNumber forknum);
-extern BlockNumber polar_rsc_search_by_ref(SMgrRelation reln, ForkNumber forknum);
-extern BlockNumber polar_rsc_search_by_mapping(SMgrRelation reln, ForkNumber forknum);
-extern BlockNumber polar_rsc_search_entry(SMgrRelation reln, ForkNumber forknum, bool evict);
-extern BlockNumber polar_rsc_update_entry(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks);
+extern BlockNumber smgrnblocks_real(struct SMgrRelationData *reln, ForkNumber forknum);
+extern BlockNumber polar_rsc_search_by_ref(struct SMgrRelationData *reln, ForkNumber forknum);
+extern BlockNumber polar_rsc_search_by_mapping(struct SMgrRelationData *reln, ForkNumber forknum);
+extern BlockNumber polar_rsc_search_entry(struct SMgrRelationData *reln, ForkNumber forknum, bool evict);
+extern BlockNumber polar_rsc_update_entry(struct SMgrRelationData *reln, ForkNumber forknum, BlockNumber nblocks);
 extern void polar_rsc_update_if_exists_and_greater_than(RelFileNode *rnode,
 														ForkNumber forknum,
 														BlockNumber nblocks);

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -21,8 +21,6 @@
 /* POLAR */
 #include "storage/polar_rsc.h"
 
-typedef struct polar_rsc_shared_relation_t polar_rsc_shared_relation_t;
-
 /*
  * smgr.c maintains a table of SMgrRelation objects, which are essentially
  * cached file handles.  An SMgrRelation is created (if not already present)
@@ -47,7 +45,7 @@ typedef struct SMgrRelationData
 	RelFileNodeBackend smgr_rnode;	/* relation physical identifier */
 
 	/* pointer to shared object, valid if non-NULL and generation matches */
-	polar_rsc_shared_relation_t *rsc_ref;
+	struct polar_rsc_shared_relation_t *rsc_ref;
 	uint64		rsc_generation;
 
 	/* pointer to owning pointer, or NULL if none */

--- a/src/test/modules/test_polar_rsc/test_polar_rsc.c
+++ b/src/test/modules/test_polar_rsc/test_polar_rsc.c
@@ -26,6 +26,8 @@
 #include "postgres.h"
 
 #include "funcapi.h"
+#include "storage/smgr.h"
+
 #include "storage/polar_rsc.h"
 
 PG_MODULE_MAGIC;


### PR DESCRIPTION
To avoid compiling issue with some extensions where c99 standard is specified.