### PR TITLE
feat: postpone waiting of sync ddl

### DIFF
--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -1280,7 +1280,7 @@ polar_get_recovery_bulk_extend_size(BlockNumber target_block, BlockNumber nblock
 	/* Avoid acceed maximum possible length */
 	bulk_extend_size = Min(MaxBlockNumber - nblocks, bulk_extend_size);
 
-	/* Extend the relation to blockNum + 1 at least */
+	/* Extend the relation to target_block + 1 at least */
 	bulk_extend_size = Max(target_block - nblocks + 1, bulk_extend_size);
 
 	return bulk_extend_size;

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -28,6 +28,7 @@
 #include "catalog/storage.h"
 #include "catalog/storage_xlog.h"
 #include "miscadmin.h"
+#include "replication/syncrep.h"
 #include "storage/bulk_write.h"
 #include "storage/freespace.h"
 #include "storage/smgr.h"
@@ -341,6 +342,9 @@ RelationTruncate(Relation rel, BlockNumber nblocks)
 			nforks++;
 		}
 	}
+
+	if (polar_enable_sync_ddl && reln->smgr_rnode.backend == InvalidBackendId)
+		polar_wait_ddl_lock();
 
 	RelationPreTruncate(rel);
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -864,8 +864,6 @@ bool		polar_enable_track_network_stat;
 bool		polar_enable_track_network_timing;
 bool		polar_enable_alloc_checkinterrupts;
 
-bool		polar_enable_sync_ddl;
-
 /* POLAR end */
 
 bool		polar_disable_escape_inside_gbk_character;
@@ -1591,13 +1589,24 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-		{"polar_enable_sync_ddl", PGC_SIGHUP, REPLICATION_STANDBY,
+		{"polar_enable_sync_ddl", PGC_USERSET, REPLICATION_STANDBY,
 			gettext_noop("Enable synchronous ddl."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NO_RESET_ALL | POLAR_GUC_IS_INVISIBLE | POLAR_GUC_IS_UNCHANGABLE
 		},
 		&polar_enable_sync_ddl,
 		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"polar_enable_sync_ddl_legacy", PGC_USERSET, REPLICATION_STANDBY,
+			gettext_noop("Enable old style synchronous ddl."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NO_RESET_ALL | POLAR_GUC_IS_INVISIBLE | POLAR_GUC_IS_UNCHANGABLE
+		},
+		&polar_enable_sync_ddl_legacy,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/replication/syncrep.h
+++ b/src/include/replication/syncrep.h
@@ -84,9 +84,13 @@ extern PGDLLIMPORT char *syncrep_parse_error_msg;
 
 /* user-settable parameters for synchronous replication */
 extern PGDLLIMPORT char *SyncRepStandbyNames;
+extern bool polar_enable_sync_ddl;
+extern bool polar_enable_sync_ddl_legacy;
+
+extern XLogRecPtr polar_ddl_lock_lsn;
 
 /* called by user backend */
-extern void SyncRepWaitForLSN(XLogRecPtr lsn, bool commit, bool polar_force_wait_apply);
+extern void SyncRepWaitForLSN(XLogRecPtr lsn, bool commit, bool sync_ddl);
 
 /* called at backend exit */
 extern void SyncRepCleanupAtProcExit(void);
@@ -120,5 +124,7 @@ extern void syncrep_scanner_finish(void);
  * POLAR: called by walsender & drop replication slot
  */
 extern bool polar_release_ddl_waiters(void);
+extern void polar_wait_ddl_lock(void);
+extern void polar_wait_ddl_lock_for_pending_deletes(void);
 
 #endif							/* _SYNCREP_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -326,7 +326,6 @@ extern bool polar_enable_debug;
 
 extern char *polar_disk_name;
 extern char *polar_storage_cluster_name;
-extern bool polar_enable_sync_ddl;
 
 /* POLAR end */
 

--- a/src/test/perl/Makefile
+++ b/src/test/perl/Makefile
@@ -27,6 +27,7 @@ install: all installdirs
 	$(INSTALL_DATA) $(srcdir)/PostgreSQL/Test/BackgroundPsql.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/PostgreSQL/Test/BackgroundPsql.pm'
 	$(INSTALL_DATA) $(srcdir)/PostgreSQL/Version.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/PostgreSQL/Version.pm'
 	$(INSTALL_DATA) $(srcdir)/PolarDB/DCRegression.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/PolarDB/DCRegression.pm'
+	$(INSTALL_DATA) $(srcdir)/PolarDB/Task.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/PolarDB/Task.pm'
 
 uninstall:
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/PostgreSQL/Test/Utils.pm'
@@ -36,5 +37,6 @@ uninstall:
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/PostgreSQL/Test/BackgroundPsql.pm'
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/PostgreSQL/Version.pm'
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/PolarDB/DCRegression.pm'
+	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/PolarDB/Task.pm'
 
 endif

--- a/src/test/polar_pl/Makefile
+++ b/src/test/polar_pl/Makefile
@@ -9,8 +9,8 @@
 export enable_fault_injector
 export with_ssl
 
-EXTRA_INSTALL = external/polar_monitor
-EXTRA_INSTALL += contrib/pg_stat_statements
+EXTRA_INSTALL = contrib/pg_stat_statements
+EXTRA_INSTALL += external/polar_monitor
 
 ifeq ($(with_ssl),openssl)
 EXTRA_INSTALL += contrib/sslinfo


### PR DESCRIPTION
Due to the shared-storage architecture, higher requirement for DDL synchronization is needed. Primary needs to acquire locks among all replicas before doing acture operation. But it cause too much waiting on PolarDB PG, some of them are just redundant. For example, primary acqueries DDL lock and do nothing. This happends really often in vacuum. And another case is create new table, truncate temp table are also waiting for the DDL lock, which is unnecessary.

In this commit, postpone the waiting of sync ddl till the actual file operations, eg, truncate and unlink. This will reduce a lot of unnecessary waitings. The waiting on the operation of temp table is also ignored. And thanks to the postpone, the waiting time can also be collapse. When the waiting begins, it's likely to have all replicas replayed beyond the point.

Add a new GUC polar_enable_sync_ddl_legacy to enable the old style synchronous ddl.