### PR TITLE
docs: update GitHub org references from ApsaraDB to polardb

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ PolarDB for PostgreSQL is an open source project based on PostgreSQL and other o
 
 Here is a checklist to prepare and submit your PR (pull request):
 
-- Create your own Github repository copy by forking `ApsaraDB/PolarDB-for-PostgreSQL`.
-- Checkout documentations [Advanced Deployment](https://apsaradb.github.io/PolarDB-for-PostgreSQL/deploying/deploy.html) for how to hack PolarDB-PG.
+- Create your own Github repository copy by forking `polardb/PolarDB-for-PostgreSQL`.
+- Checkout documentations [Advanced Deployment](https://polardb.github.io/polardb-pg-docs/deploying/deploy.html) for how to hack PolarDB-PG.
 - Run `make stylecheck` to format your code, and push changes to your personal fork.
 - Edit detailed commit message, and create a PR to upstream.
 - Wait for all CI checks to pass.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![logo](https://raw.githubusercontent.com/polardb/polardb-pg-docs/main/docs/.vuepress/public/images/polardb.png)](https://apsaradb.github.io/PolarDB-for-PostgreSQL/)
+[![logo](https://raw.githubusercontent.com/polardb/polardb-pg-docs/main/docs/.vuepress/public/images/polardb.png)](https://polardb.github.io/polardb-pg-docs/)
 
 # PolarDB for PostgreSQL
 
@@ -8,17 +8,17 @@
 
 #### English | [简体中文](./README_zh.md)
 
-[![official](https://img.shields.io/badge/official%20site-blueviolet?style=flat&logo=alibabacloud)](https://apsaradb.github.io/PolarDB-for-PostgreSQL/)
+[![official](https://img.shields.io/badge/official%20site-blueviolet?style=flat&logo=alibabacloud)](https://polardb.github.io/polardb-pg-docs/)
 
-[![GitHub License](https://img.shields.io/github/license/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=apache)](./LICENSE)
-[![github-issues](https://img.shields.io/github/issues/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/issues)
-[![github-pullrequest](https://img.shields.io/github/issues-pr/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/pulls)
-[![GitHub Discussions](https://img.shields.io/github/discussions/ApsaraDB/PolarDB-for-PostgreSQL?logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/discussions)
-[![github-forks](https://img.shields.io/github/forks/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/network/members)
-[![github-stars](https://img.shields.io/github/stars/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/stargazers)
-[![github-contributors](https://img.shields.io/github/contributors/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/graphs/contributors)
-[![GitHub deployments](<https://img.shields.io/github/deployments/ApsaraDB/PolarDB-for-PostgreSQL/github-pages?logo=github&label=github-pages%20(docs)>)](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/)
-[![GitHub branch check runs](<https://img.shields.io/github/check-runs/ApsaraDB/PolarDB-for-PostgreSQL/POLARDB_15_STABLE?logo=github&label=checks%20(v15)>)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/tree/POLARDB_15_STABLE)
+[![GitHub License](https://img.shields.io/github/license/polardb/PolarDB-for-PostgreSQL?style=flat&logo=apache)](./LICENSE)
+[![github-issues](https://img.shields.io/github/issues/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/issues)
+[![github-pullrequest](https://img.shields.io/github/issues-pr/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/pulls)
+[![GitHub Discussions](https://img.shields.io/github/discussions/polardb/PolarDB-for-PostgreSQL?logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/discussions)
+[![github-forks](https://img.shields.io/github/forks/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/network/members)
+[![github-stars](https://img.shields.io/github/stars/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/stargazers)
+[![github-contributors](https://img.shields.io/github/contributors/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/graphs/contributors)
+[![GitHub deployments](<https://img.shields.io/github/deployments/polardb/polardb-pg-docs/github-pages?logo=github&label=github-pages%20(docs)>)](https://polardb.github.io/polardb-pg-docs/zh/)
+[![GitHub branch check runs](<https://img.shields.io/github/check-runs/polardb/PolarDB-for-PostgreSQL/POLARDB_15_STABLE?logo=github&label=checks%20(v15)>)](https://github.com/polardb/PolarDB-for-PostgreSQL/tree/POLARDB_15_STABLE)
 [![Leaderboard](https://img.shields.io/badge/PolarDB--for--PostgreSQL-Check%20Your%20Contribution-orange?style=flat&logo=alibabacloud)](https://opensource.alibaba.com/contribution_leaderboard/details?projectValue=polardb-pg)
 
 </div>
@@ -51,7 +51,7 @@ PolarDB for PostgreSQL uses a shared-storage-based architecture in which computi
 
 After computing is decoupled from storage, the I/O latency and throughput increase. When a single read-only node is used to process analytical queries, the CPUs, memory, and I/O of other read-only nodes and the large storage I/O bandwidth cannot be fully utilized. To resolve this issue, PolarDB provides the shared-storage-based MPP engine. The engine can use CPUs to accelerate analytical queries at SQL level and support a mix of OLAP workloads and OLTP workloads for HTAP.
 
-For more information, see [Architecture](https://apsaradb.github.io/PolarDB-for-PostgreSQL/theory/arch-overview.html).
+For more information, see [Architecture](https://polardb.github.io/polardb-pg-docs/theory/arch-overview.html).
 
 ## Quick Start with PolarDB
 
@@ -69,31 +69,31 @@ postgres=# SELECT version();
 (1 row)
 ```
 
-For more advanced deployment way, please refer to [Advanced Deployment](https://apsaradb.github.io/PolarDB-for-PostgreSQL/deploying/deploy.html). Before your deployment, we recommand to figure out the [Architecture](https://apsaradb.github.io/PolarDB-for-PostgreSQL/deploying/introduction.html) of PolarDB for PostgreSQL.
+For more advanced deployment way, please refer to [Advanced Deployment](https://polardb.github.io/polardb-pg-docs/deploying/deploy.html). Before your deployment, we recommand to figure out the [Architecture](https://polardb.github.io/polardb-pg-docs/deploying/introduction.html) of PolarDB for PostgreSQL.
 
 ## Development
 
-Please refer to [Development Guide](https://apsaradb.github.io/PolarDB-for-PostgreSQL/development/dev-on-docker.html) to compile and development PolarDB for PostgreSQL.
+Please refer to [Development Guide](https://polardb.github.io/polardb-pg-docs/development/dev-on-docker.html) to compile and development PolarDB for PostgreSQL.
 
 ## Documentation
 
-Please refer to [Online Documentation Website](https://apsaradb.github.io/PolarDB-for-PostgreSQL/) to see the whole documentations.
+Please refer to [Online Documentation Website](https://polardb.github.io/polardb-pg-docs/) to see the whole documentations.
 
-If you want to explore or develop documentation locally, see [Document Contribution](https://apsaradb.github.io/PolarDB-for-PostgreSQL/contributing/contributing-polardb-docs.html).
+If you want to explore or develop documentation locally, see [Document Contribution](https://polardb.github.io/polardb-pg-docs/contributing/contributing-polardb-docs.html).
 
 ## Contributing
 
 You are welcome to make contributions to PolarDB for PostgreSQL. Here are the contributors:
 
-<a href="https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=ApsaraDB/PolarDB-for-PostgreSQL" />
+<a href="https://github.com/polardb/PolarDB-for-PostgreSQL/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=polardb/PolarDB-for-PostgreSQL" />
 </a>
 
 Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ApsaraDB/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#ApsaraDB/PolarDB-for-PostgreSQL&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#polardb/PolarDB-for-PostgreSQL&Date)
 
 ## Software License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![logo](https://raw.githubusercontent.com/polardb/polardb-pg-docs/main/docs/.vuepress/public/images/polardb.png)](https://apsaradb.github.io/PolarDB-for-PostgreSQL/)
+[![logo](https://raw.githubusercontent.com/polardb/polardb-pg-docs/main/docs/.vuepress/public/images/polardb.png)](https://polardb.github.io/polardb-pg-docs/)
 
 # PolarDB for PostgreSQL
 
@@ -10,15 +10,15 @@
 
 [![official](https://img.shields.io/badge/官方网站-blueviolet?style=flat&logo=alibabacloud)](https://www.polardbpg.com/home)
 
-[![GitHub License](https://img.shields.io/github/license/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=apache)](./LICENSE)
-[![github-issues](https://img.shields.io/github/issues/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/issues)
-[![github-pullrequest](https://img.shields.io/github/issues-pr/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/pulls)
-[![GitHub Discussions](https://img.shields.io/github/discussions/ApsaraDB/PolarDB-for-PostgreSQL?logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/discussions)
-[![github-forks](https://img.shields.io/github/forks/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/network/members)
-[![github-stars](https://img.shields.io/github/stars/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/stargazers)
-[![github-contributors](https://img.shields.io/github/contributors/ApsaraDB/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/graphs/contributors)
-[![GitHub deployments](<https://img.shields.io/github/deployments/ApsaraDB/PolarDB-for-PostgreSQL/github-pages?logo=github&label=github-pages%20(docs)>)](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/)
-[![GitHub branch check runs](<https://img.shields.io/github/check-runs/ApsaraDB/PolarDB-for-PostgreSQL/POLARDB_15_STABLE?logo=github&label=checks%20(v15)>)](https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/tree/POLARDB_15_STABLE)
+[![GitHub License](https://img.shields.io/github/license/polardb/PolarDB-for-PostgreSQL?style=flat&logo=apache)](./LICENSE)
+[![github-issues](https://img.shields.io/github/issues/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/issues)
+[![github-pullrequest](https://img.shields.io/github/issues-pr/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/pulls)
+[![GitHub Discussions](https://img.shields.io/github/discussions/polardb/PolarDB-for-PostgreSQL?logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/discussions)
+[![github-forks](https://img.shields.io/github/forks/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/network/members)
+[![github-stars](https://img.shields.io/github/stars/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/stargazers)
+[![github-contributors](https://img.shields.io/github/contributors/polardb/PolarDB-for-PostgreSQL?style=flat&logo=github)](https://github.com/polardb/PolarDB-for-PostgreSQL/graphs/contributors)
+[![GitHub deployments](<https://img.shields.io/github/deployments/polardb/polardb-pg-docs/github-pages?logo=github&label=github-pages%20(docs)>)](https://polardb.github.io/polardb-pg-docs/zh/)
+[![GitHub branch check runs](<https://img.shields.io/github/check-runs/polardb/PolarDB-for-PostgreSQL/POLARDB_15_STABLE?logo=github&label=checks%20(v15)>)](https://github.com/polardb/PolarDB-for-PostgreSQL/tree/POLARDB_15_STABLE)
 [![Leaderboard](https://img.shields.io/badge/PolarDB--for--PostgreSQL-开源贡献榜-orange?style=flat&logo=alibabacloud)](https://opensource.alibaba.com/contribution_leaderboard/details?projectValue=polardb-pg)
 
 </div>
@@ -51,7 +51,7 @@ PolarDB for PostgreSQL 采用了基于 Shared-Storage 的存储计算分离架�
 
 在存储计算分离后，I/O 单路延迟变大的同时，I/O 的吞吐也变大了。在处理分析型查询时，仅使用单个只读节点无法发挥出存储侧的大 I/O 带宽优势，也无法利用其他只读节点的 CPU、内存和 I/O 资源。为了解决该问题，PolarDB 研发了基于 Shared-Storage 的并行执行引擎，能够在 SQL 级别上弹性利用任意数目的 CPU 来加速分析查询，支持 HTAP 的混合负载场景。
 
-详情请查阅 [产品架构](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/theory/arch-overview.html)。
+详情请查阅 [产品架构](https://polardb.github.io/polardb-pg-docs/zh/theory/arch-overview.html)。
 
 ## 快速部署
 
@@ -69,29 +69,29 @@ postgres=# SELECT version();
 (1 row)
 ```
 
-对于更多进阶部署方式，请移步在线文档中的 [进阶部署](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/deploying/deploy.html)。在部署前，了解 PolarDB for PostgreSQL 的 [架构简介](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/deploying/introduction.html) 能够深化对每个步骤的理解。
+对于更多进阶部署方式，请移步在线文档中的 [进阶部署](https://polardb.github.io/polardb-pg-docs/zh/deploying/deploy.html)。在部署前，了解 PolarDB for PostgreSQL 的 [架构简介](https://polardb.github.io/polardb-pg-docs/zh/deploying/introduction.html) 能够深化对每个步骤的理解。
 
 ## 开发
 
-参考 [开发指南](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/development/dev-on-docker.html) 进行源码编译和开发。
+参考 [开发指南](https://polardb.github.io/polardb-pg-docs/zh/development/dev-on-docker.html) 进行源码编译和开发。
 
 ## 文档
 
-请移步本项目的 [在线文档网站](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/) 查阅完整文档。
+请移步本项目的 [在线文档网站](https://polardb.github.io/polardb-pg-docs/zh/) 查阅完整文档。
 
-如果需要在本地预览或开发文档，请参考 [贡献文档](https://apsaradb.github.io/PolarDB-for-PostgreSQL/zh/contributing/contributing-polardb-docs.html)。
+如果需要在本地预览或开发文档，请参考 [贡献文档](https://polardb.github.io/polardb-pg-docs/zh/contributing/contributing-polardb-docs.html)。
 
 ## 参与贡献
 
 我们诚挚欢迎社区参与 PolarDB for PostgreSQL 的贡献。以下是贡献者列表（由 [contrib.rocks](https://contrib.rocks) 支持）：
 
-<a href="https://github.com/ApsaraDB/PolarDB-for-PostgreSQL/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=ApsaraDB/PolarDB-for-PostgreSQL" />
+<a href="https://github.com/polardb/PolarDB-for-PostgreSQL/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=polardb/PolarDB-for-PostgreSQL" />
 </a>
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ApsaraDB/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#ApsaraDB/PolarDB-for-PostgreSQL&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#polardb/PolarDB-for-PostgreSQL&Date)
 
 ## 软件许可
 


### PR DESCRIPTION
## Summary

- The repository was moved from the ApsaraDB GitHub organization to
  the polardb organization two months ago. The old ApsaraDB org has
  since been taken over by an unrelated project, making the existing
  redirects unsafe to rely on.
- Update all repository links and CI badge references to use
  `github.com/polardb/PolarDB-for-PostgreSQL`.
- Update all documentation page links from
  `apsaradb.github.io/PolarDB-for-PostgreSQL` to
  `polardb.github.io/polardb-pg-docs`, which is the dedicated docs
  repository under the new organization.
- Fix the GitHub deployments badge to reference
  `polardb/polardb-pg-docs`, where GitHub Pages is now deployed.

## Test plan

- [ ] All links in `README.md`, `README_zh.md`, and `CONTRIBUTING.md`
      point to the new organization and docs site
- [ ] Badges render correctly against the new repository paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)