### PR TITLE
ci: use sync token for upstream mirroring

### DIFF
--- a/.github/workflows/sync-postgres.yml
+++ b/.github/workflows/sync-postgres.yml
@@ -20,11 +20,11 @@ jobs:
           source_branch: "REL_*"
           destination_branch: "REL_*"
           sync_tags: "true"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SYNC_TOKEN }}
       - name: repo-sync-master
         uses: repo-sync/github-sync@master
         with:
           source_repo: https://git.postgresql.org/git/postgresql.git
           source_branch: master
           destination_branch: master
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

Use the repository-provided sync token for the upstream PostgreSQL mirror job so branch updates that include workflow metadata can be pushed successfully.

## Testing

Not run; workflow configuration change only.