### PR TITLE
ci: support packaging on Ubuntu 26.04

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         arch: [ ubuntu-24.04, ubuntu-24.04-arm ]
-        base_image: [ ubuntu20.04, ubuntu22.04, ubuntu24.04, debian11, debian12, debian13 ]
+        base_image: [ ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu26.04, debian11, debian12, debian13 ]
     runs-on: ${{ matrix.arch }}
     steps:
       - name: fetch source code

--- a/package/debian/control
+++ b/package/debian/control
@@ -1,6 +1,6 @@
 Package: polardb-for-postgresql
 Maintainer: mrdrivingduck <mrdrivingduck@gmail.com>
-Depends: libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76, libkrb5-3, libldap-2.4-2 | libldap-2.5-0 | libldap2
+Depends: libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76 | libicu78, libkrb5-3, libldap-2.4-2 | libldap-2.5-0 | libldap2
 Section: database
 Priority: optional
 Homepage: https://github.com/ApsaraDB/PolarDB-for-PostgreSQL


### PR DESCRIPTION
Enable package builds for Ubuntu 26.04 while retaining coverage for existing distributions.

Allow packages built on Ubuntu 26.04 to declare their required ICU library.