### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#polardb/PolarDB-for-PostgreSQL&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.dera.page/#polardb/PolarDB-for-PostgreSQL&Date)
 
 ## Software License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -91,7 +91,7 @@ postgres=# SELECT version();
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.com/#polardb/PolarDB-for-PostgreSQL&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=polardb/PolarDB-for-PostgreSQL&type=Date)](https://star-history.dera.page/#polardb/PolarDB-for-PostgreSQL&Date)
 
 ## 软件许可
 


### PR DESCRIPTION
The star history chart on the project page is currently broken and shows no
data. This change migrates the chart to a working rendering service while
keeping the exact same visual style and layout, restoring the star history
for both the English and Chinese README files.