### PR TITLE
ci: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.arch }}
     steps:
       - name: fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: create and start the container
         run: |
           docker create                                                    \
@@ -59,7 +59,7 @@ jobs:
           echo "rpmpath=$RPMPATH/$RPMNAME" >> $GITHUB_ENV
       - name: upload artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.rpmname }}
           path: ${{ env.rpmpath }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ matrix.arch }}
     steps:
       - name: fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: create and start the container
         run: |
           docker create                                                    \
@@ -102,7 +102,7 @@ jobs:
           cd ./package/debian && DEBNAME=`ls *.deb` && echo "debname=$DEBNAME" >> $GITHUB_ENV
       - name: upload artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.debname }}
           path: ./package/debian/${{ env.debname }}
@@ -117,13 +117,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: |
             *.{rpm,deb}
           merge-multiple: true
       - name: upload artifacts to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             *.rpm

--- a/.github/workflows/precheck.yml
+++ b/.github/workflows/precheck.yml
@@ -28,13 +28,14 @@ jobs:
   regression:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container_image: [ rocky8, rocky9, ubuntu22.04 ]
         rules: [ precheck-main, plcheck ]
         debug_mode: [ on, off ]
     steps:
       - name: fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: free disk space
         run: |

--- a/.github/workflows/stylecheck.yml
+++ b/.github/workflows/stylecheck.yml
@@ -14,7 +14,7 @@ jobs:
         container_image: [ anolis8 ]
     steps:
       - name: fetch source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         # for copyright check
         with:
           fetch-depth: 0

--- a/.github/workflows/sync-postgres.yml
+++ b/.github/workflows/sync-postgres.yml
@@ -9,7 +9,7 @@ jobs:
   repo-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: repo-sync-all


### PR DESCRIPTION
Updates root GitHub Actions to their supported runtime versions and disables precheck matrix fail-fast so a failed matrix job does not cancel the others.